### PR TITLE
Added support for Youtube Music

### DIFF
--- a/ytdl.prj.xml
+++ b/ytdl.prj.xml
@@ -2205,7 +2205,7 @@ This step will delete the following directory:  /sdcard/Tasker/ytdl/*</Str>
 				<Condition sr="c0" ve="3">
 					<lhs>%url</lhs>
 					<op>4</op>
-					<rhs>^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(\/(?:[\w\-]+\?v=|embed\/|v\/)?)([\w\-]+)(\S+)?$</rhs>
+					<rhs>^((?:https?:)?\/\/)?((?:www|m|music)\.)?((?:youtube\.com|youtu.be))(\/(?:[\w\-]+\?v=|embed\/|v\/)?)([\w\-]+)(\S+)?$</rhs>
 				</Condition>
 			</ConditionList>
 		</Action>


### PR DESCRIPTION
Youtube Music links are ignored by ytdl_check_url task. This change added support for music.youtube.com urls so also links from Youtube Music are now supported.